### PR TITLE
Add edit/delete options and ownership checks for Bill and BillEntry

### DIFF
--- a/backend/splitflow/decorators.py
+++ b/backend/splitflow/decorators.py
@@ -1,0 +1,20 @@
+from functools import wraps
+from rest_framework.response import Response
+from rest_framework import status
+from django.shortcuts import get_object_or_404
+from .models import Account, BillEntry
+
+def check_entry_owner(view_func):
+    @wraps(view_func)
+    def _wrapped_view(request, entry_id, *args, **kwargs):
+        account_id = request.data.get("account_id") or request.query_params.get("account_id")
+        if not account_id:
+            return Response({"detail": "Account ID required."}, status=status.HTTP_400_BAD_REQUEST)
+
+        entry = get_object_or_404(BillEntry, pk=entry_id)
+        if entry.user.id != int(account_id):
+            return Response({"detail": "Not allowed."}, status=status.HTTP_403_FORBIDDEN)
+
+        request.entry = entry
+        return view_func(request, entry_id, *args, **kwargs)
+    return _wrapped_view

--- a/backend/splitflow/serializers.py
+++ b/backend/splitflow/serializers.py
@@ -24,6 +24,7 @@ class BillSerializer(serializers.ModelSerializer):
 
 class UserJoinedBillSerializer(serializers.ModelSerializer):
     created_on = serializers.SerializerMethodField()
+    created_by = serializers.SerializerMethodField()
 
     class Meta:
         model = Bill
@@ -31,3 +32,6 @@ class UserJoinedBillSerializer(serializers.ModelSerializer):
 
     def get_created_on(self, obj):
         return obj.created_on.date()
+
+    def get_created_by(self, obj):
+        return obj.created_by.username

--- a/backend/splitflow/urls.py
+++ b/backend/splitflow/urls.py
@@ -2,9 +2,9 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("bills", views.bill_list_create, name="bill-list-create"),
-    path("bills/<int:pk>", views.bill_detail, name="bill-detail"),
-    path("bills-by-user/<int:account_id>", views.bills_by_user, name="bills-by-user"),
-    path("bills/<int:bill_id>/entries", views.bill_entry_create, name="bill-entry-create"),
-    path("bills/leave/<int:account_id>", views.leave_bills, name="bill-leave"),
+    path("create-bill", views.bill_list_create, name="bill-list-create"),
+    path("<int:bill_id>/bill-details", views.bill_detail, name="bill-detail"),
+    path("<int:bill_id>/bills/entries", views.bill_entry_create, name="bill-entry-create"),
+    path("<int:account_id>/bills-by-user", views.bills_by_user, name="bills-by-user"),
+    path("<int:account_id>/bill-leave", views.leave_bills, name="bill-leave"),
 ]

--- a/backend/splitflow/urls.py
+++ b/backend/splitflow/urls.py
@@ -4,8 +4,10 @@ from . import views
 urlpatterns = [
     path("create-bill", views.bill_list_create, name="bill-list-create"),
     path("<int:bill_id>/bill-details", views.bill_detail, name="bill-detail"),
-    path("<int:bill_id>/bills/entries", views.bill_entry_create, name="bill-entry-create"),
     path("<int:bill_id>/bill-edit", views.bill_edit, name="bill-edit"),
-    path("<int:account_id>/bills-by-user", views.bills_by_user, name="bills-by-user"),
     path("<int:account_id>/bill-leave", views.leave_bills, name="bill-leave"),
+    path("<int:bill_id>/bills/entries", views.bill_entry_create, name="bill-entry-create"),
+    path("<int:entry_id>/bill-entries/edit", views.bill_entry_edit, name="bill-entry-edit"),
+    path("<int:entry_id>/bill-entries/delete", views.bill_entry_delete, name="bill-entry-delete"),
+    path("<int:account_id>/bills-by-user", views.bills_by_user, name="bills-by-user")
 ]

--- a/backend/splitflow/urls.py
+++ b/backend/splitflow/urls.py
@@ -5,6 +5,7 @@ urlpatterns = [
     path("create-bill", views.bill_list_create, name="bill-list-create"),
     path("<int:bill_id>/bill-details", views.bill_detail, name="bill-detail"),
     path("<int:bill_id>/bills/entries", views.bill_entry_create, name="bill-entry-create"),
+    path("<int:bill_id>/bill-edit", views.bill_edit, name="bill-edit"),
     path("<int:account_id>/bills-by-user", views.bills_by_user, name="bills-by-user"),
     path("<int:account_id>/bill-leave", views.leave_bills, name="bill-leave"),
 ]

--- a/backend/splitflow/views.py
+++ b/backend/splitflow/views.py
@@ -1,6 +1,8 @@
 from django.http import JsonResponse
 from rest_framework.decorators import api_view
 from rest_framework import status
+
+from .decorators import check_entry_owner
 from .models import Bill, BillEntry, BillUser
 from .serializers import BillSerializer, BillEntrySerializer, UserJoinedBillSerializer
 from accounts.models import Account
@@ -67,6 +69,7 @@ def bill_entry_create(request, bill_id):
     return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 @api_view(["PUT", "PATCH"])
+@check_entry_owner
 def bill_entry_edit(request, entry_id):
     try:
         entry = BillEntry.objects.get(pk=entry_id)
@@ -80,6 +83,7 @@ def bill_entry_edit(request, entry_id):
     return JsonResponse(serializer.errors, status=400)
 
 @api_view(["DELETE"])
+@check_entry_owner
 def bill_entry_delete(request, entry_id):
     try:
         entry = BillEntry.objects.get(pk=entry_id)

--- a/backend/splitflow/views.py
+++ b/backend/splitflow/views.py
@@ -66,6 +66,19 @@ def bill_entry_create(request, bill_id):
         return JsonResponse(serializer.data, status=status.HTTP_201_CREATED)
     return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+@api_view(["PUT", "PATCH"])
+def bill_edit(request, bill_id):
+    try:
+        bill = Bill.objects.get(pk=bill_id)
+    except Bill.DoesNotExist:
+        return JsonResponse({"error": "Bill not found"}, status=404)
+
+    serializer = BillSerializer(bill, data=request.data, partial=(request.method=="PATCH"))
+    if serializer.is_valid():
+        serializer.save()
+        return JsonResponse(serializer.data)
+    return JsonResponse(serializer.errors, status=400)
+
 @api_view(["POST"])
 def leave_bills(request, account_id):
     user = Account.objects.get(id=account_id)

--- a/backend/splitflow/views.py
+++ b/backend/splitflow/views.py
@@ -67,6 +67,29 @@ def bill_entry_create(request, bill_id):
     return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 @api_view(["PUT", "PATCH"])
+def bill_entry_edit(request, entry_id):
+    try:
+        entry = BillEntry.objects.get(pk=entry_id)
+    except BillEntry.DoesNotExist:
+        return JsonResponse({"error": "Entry not found"}, status=404)
+
+    serializer = BillEntrySerializer(entry, data=request.data, partial=(request.method=="PATCH"))
+    if serializer.is_valid():
+        serializer.save()
+        return JsonResponse(serializer.data)
+    return JsonResponse(serializer.errors, status=400)
+
+@api_view(["DELETE"])
+def bill_entry_delete(request, entry_id):
+    try:
+        entry = BillEntry.objects.get(pk=entry_id)
+    except BillEntry.DoesNotExist:
+        return JsonResponse({"error": "Entry not found"}, status=404)
+
+    entry.delete()
+    return JsonResponse({"message": "Bill entry deleted successfully"}, status=204)
+
+@api_view(["PUT", "PATCH"])
 def bill_edit(request, bill_id):
     try:
         bill = Bill.objects.get(pk=bill_id)

--- a/backend/splitflow/views.py
+++ b/backend/splitflow/views.py
@@ -34,9 +34,9 @@ def bills_by_user(request, account_id):
     return JsonResponse(serializer.data, safe=False)
 
 @api_view(["GET"])
-def bill_detail(request, pk):
+def bill_detail(request, bill_id):
     try:
-        bill = Bill.objects.get(pk=pk)
+        bill = Bill.objects.get(pk=bill_id)
     except Bill.DoesNotExist:
         return JsonResponse({"error": "Bill not found"}, status=404)
 


### PR DESCRIPTION
New endpoints updated to show request titles clearly in the path.
Fixed created_by to display username instead of account ID.
Added Bill edit functionality.
Added BillEntry edit and delete functionality.
Implemented check_entry_owner decorator on BillEntry edit/delete endpoints to restrict actions to the creator only.
Improves clarity, usability, and enforces ownership permissions across endpoints.